### PR TITLE
Updates to out-of-date dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '7'
   - '6'
   - '5'
   - '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
+  - '6'
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'
 cache:
   directories:
     - node_modules

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 /* eslint new-cap: [2, {"capIsNewExceptions": ["extractor.Extract"]}] */
 'use strict'
 
-var Promise = require('pinkie-promise')
 var path = require('path')
+var fs = require('fs')
+var Promise = require('pinkie-promise')
 var request = require('request')
 var child = require('child-process-promise')
-var fs = require('fs')
 var vdf = require('vdf')
+
 var _ = {}
 _.defaults = require('lodash.defaults')
 
@@ -47,7 +48,7 @@ var downloadIfNeeded = function (opts) {
   try {
     fs.statSync(opts.binDir)
     return Promise.resolve()
-  } catch (e) {
+  } catch (err) {
     return download(opts)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steamcmd",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Call steamcmd from node.js",
   "license": "MIT",
   "repository": "mathphreak/node-steamcmd",
@@ -10,7 +10,7 @@
     "url": "mathphreak.me"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.7.0"
   },
   "scripts": {
     "test": "xo && ava"
@@ -22,20 +22,20 @@
     "steamcmd"
   ],
   "dependencies": {
-    "child-process-promise": "1.1.0",
-    "lodash.defaults": "4.0.1",
-    "pinkie-promise": "2.0.0",
-    "request": "2.69.0",
+    "child-process-promise": "2.2.0",
+    "lodash.defaults": "4.2.0",
+    "pinkie-promise": "2.0.1",
+    "request": "2.79.0",
     "tar": "2.2.1",
     "unzip": "0.1.11",
     "vdf": "0.0.2"
   },
   "devDependencies": {
-    "ava": "0.12.0",
-    "del": "2.2.0",
+    "ava": "0.17.0",
+    "del": "2.2.2",
     "mkdirp": "0.5.1",
     "tempfile": "1.1.1",
-    "xo": "0.12.1"
+    "xo": "0.17.1"
   },
   "xo": {
     "semicolon": false,

--- a/test.js
+++ b/test.js
@@ -1,12 +1,12 @@
-import test from 'ava'
-import steamcmd from './'
 import fs from 'fs'
+import path from 'path'
 import tempfile from 'tempfile'
 import mkdirp from 'mkdirp'
-import path from 'path'
+import test from 'ava'
 import del from 'del'
+import steamcmd from './'
 
-test.beforeEach((t) => {
+test.beforeEach(t => {
   const binDirParent = tempfile('/')
   mkdirp.sync(binDirParent)
   const binDir = path.join(binDirParent, 'steamcmd_bin')
@@ -14,11 +14,11 @@ test.beforeEach((t) => {
   t.context = {binDirParent, binDir, opts}
 })
 
-test.afterEach(async (t) => {
+test.afterEach(async t => {
   await del(t.context.binDirParent, {force: true})
 })
 
-test('download', async (t) => {
+test('download', async t => {
   var {binDir, opts} = t.context
   await steamcmd.download(opts)
   t.notThrows(() => {
@@ -26,18 +26,18 @@ test('download', async (t) => {
   })
 })
 
-test('touch', async (t) => {
+test('touch', async t => {
   var {binDir, opts} = t.context
   await steamcmd.download(opts)
   // fix random EBUSY on Windows
-  await new Promise((resolve) => setTimeout(resolve, 200))
+  await new Promise(resolve => setTimeout(resolve, 200))
   await steamcmd.touch(opts)
   t.notThrows(() => {
     fs.statSync(path.join(binDir, 'public'))
   })
 })
 
-test('prep', async (t) => {
+test('prep', async t => {
   var {binDir, opts} = t.context
   await steamcmd.prep(opts)
   t.notThrows(() => {
@@ -45,21 +45,21 @@ test('prep', async (t) => {
   })
 })
 
-test('getAppInfo', async (t) => {
+test('getAppInfo', async t => {
   var {opts} = t.context
   await steamcmd.download(opts)
   // fix random EBUSY on Windows
-  await new Promise((resolve) => setTimeout(resolve, 200))
+  await new Promise(resolve => setTimeout(resolve, 200))
   await steamcmd.touch(opts)
   const csgoAppInfo = await steamcmd.getAppInfo(730, opts)
   t.is(csgoAppInfo.common.name, 'Counter-Strike: Global Offensive')
 })
 
-test('repeated calls to getAppInfo', async (t) => {
+test('repeated calls to getAppInfo', async t => {
   var {opts} = t.context
   await steamcmd.download(opts)
   // fix random EBUSY on Windows
-  await new Promise((resolve) => setTimeout(resolve, 200))
+  await new Promise(resolve => setTimeout(resolve, 200))
   await steamcmd.touch(opts)
   const csgoAppInfo = await steamcmd.getAppInfo(730, opts)
   t.is(csgoAppInfo.common.name, 'Counter-Strike: Global Offensive')


### PR DESCRIPTION
Updates the dependencies in the project to the latest at this time.

Main one is to update "Request", which resolves https://nodesecurity.io/advisories/130

XO has changed the default ruleset, so these have been fixed at the same time. Let me know if you would rather have these pulled out seperately.

NOTE: updating all of these dependencies causes EOL versions of node to fail (v0.10 & v0.12), hence the need for a major version bump.