### PR TITLE
updateApp returns false when app up-to-date

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,9 @@ var updateApp = function (appId, installDir, opts) {
       if (proc.stdout.indexOf('Success! App \'' + appId + '\' fully installed') !== -1) {
         return true
       }
+      if (proc.stdout.indexOf('Success! App \'' + appId + '\' already up to date.') !== -1) {
+        return false
+      }
 
       var stdoutArray = proc.stdout.replace('\r\n', '\n').split('\n')
       return Promise.reject(new Error('Unable to update ' + appId + '. \n SteamCMD error was ' + stdoutArray[stdoutArray.length - 2]))

--- a/test.js
+++ b/test.js
@@ -108,3 +108,12 @@ test('updateApp with HLDS workaround', async t => {
   await steamcmd.touch(opts)
   t.true(await steamcmd.updateApp(90, path.resolve('test_data', 'hlds'), opts))
 })
+
+test('updateApp on already up-to-date app returns false', async t => {
+  var {binDirParent, opts} = t.context
+  const appId = 1007
+  const installDir = path.join(binDirParent, 'app')
+  await steamcmd.prep(opts)
+  await steamcmd.updateApp(appId, installDir, opts)
+  t.false(await steamcmd.updateApp(appId, installDir, opts))
+})


### PR DESCRIPTION
This PR changes the return signature of `updateApp` per #4.

Current:
* app updated - returns true
* else - returns an error containing the process stdout

Proposed:
* app updated - returns true
* app up-to-date - returns false
* else - returns an error containing the process stdout

Contains a test, which passes with the rest on my local machine.