### PR TITLE
Fix getAppInfo

### DIFF
--- a/test.js
+++ b/test.js
@@ -56,6 +56,8 @@ test('getAppInfo', async t => {
   await steamcmd.prep(opts)
   const csgoAppInfo = await steamcmd.getAppInfo(730, opts)
   t.is(csgoAppInfo.common.name, 'Counter-Strike: Global Offensive')
+  // Ensure the whole text is parsed by checking the last element
+  t.truthy(csgoAppInfo.ufs)
 })
 
 test('repeated calls to getAppInfo', async t => {


### PR DESCRIPTION
This PR aims to fix two issues mentioned in https://github.com/mathphreak/node-steamcmd/issues/4:

* getAppInfo is missing some of the data returned by steam
* getAppInfo's result has erroneous text

The first of the two commits in this PR includes a test that demonstrates the issue. The test fails until the final commit is in place.

Regarding the single `todo` remaining within the commited code, it would be a clean fix if I was able to use async/await within index.js, but that would bring a dependency on Node >= 6.4. I'll open a second issue to discuss that.