### PR TITLE
Add getAppVersionRemote

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,19 @@ var getAppInfo = function (appID, opts) {
     })
 }
 
+var getAppVersionRemote = function (appId, branchId, opts) {
+  return getAppInfo(appId, opts).then(function (appInfo) {
+    branchId = branchId || 'public'
+    var branch = appInfo.depots.branches[branchId]
+    return {
+      buildId: branch.buildid,
+      description: branch.description,
+      updatedAt: branch.timeupdated ?
+        new Date(parseInt(branch.timeupdated, 10) * 1000) : undefined
+    }
+  })
+}
+
 var updateApp = function (appId, installDir, opts) {
   opts = _.defaults(opts, defaultOptions)
   if (!path.isAbsolute(installDir)) {
@@ -175,4 +188,5 @@ module.exports.download = downloadIfNeeded
 module.exports.touch = touch
 module.exports.prep = prep
 module.exports.getAppInfo = getAppInfo
+module.exports.getAppVersionRemote = getAppVersionRemote
 module.exports.updateApp = updateApp

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,10 @@ Runs `download([opts])`, waits briefly to avoid `EBUSY`, then runs
 ### steamcmd.getAppInfo(appid[, opts])
 Asks SteamCMD to get the latest app info for the given app.
 
+### steamcmd.getAppVersionRemote(appid[, branch [, opts]])
+Returns an object identifying the most recent available build for an app.
+Searches for a particular branch if provided, otherwise defaults to 'public'.
+
 ### steamcmd.updateApp(appid, installDir[, opts])
 Asks SteamCMD to install/update the given app to the given **absolute**
 directory. Throws a `TypeError` if `installDir` is not absolute.

--- a/test.js
+++ b/test.js
@@ -68,6 +68,21 @@ test('repeated calls to getAppInfo', async t => {
   t.notThrows(steamcmd.getAppInfo(730, opts))
 })
 
+test('getAppVersionRemote', async t => {
+  var {opts} = t.context
+  await steamcmd.prep(opts)
+  // main branch
+  let info = await steamcmd.getAppVersionRemote(730, '', opts)
+  t.regex(info.buildId, /\d+/)
+  t.falsy(info.description)
+  t.true(info.updatedAt && new Date(0) < info.updatedAt)
+  // different branch
+  info = await steamcmd.getAppVersionRemote(730, '1.21.3.1', opts)
+  t.is(info.buildId, '611429')
+  t.is(info.description, 'Game version 1.21.3.1 (16-Nov-2012)')
+  t.falsy(info.updatedAt)
+})
+
 test('updateApp with a relative path', async t => {
   var {opts} = t.context
   await steamcmd.prep(opts)


### PR DESCRIPTION
This PR requires and is thus based on #10. It adds a new method `getAppVersionRemote` which returns an object representing the most recently released build for a particular app and branch.